### PR TITLE
Feature: Ability to seek track to specific millisecond

### DIFF
--- a/Source/Jukebox.swift
+++ b/Source/Jukebox.swift
@@ -134,17 +134,17 @@ extension Jukebox {
      - parameter shouldPlay: pass true if playback should be resumed after seeking
      */
     public func seek(toSecond second: Int, shouldPlay: Bool = false) {
-        guard let player = player, let item = currentItem else {return}
-        
-        player.seekToTime(CMTimeMake(Int64(second), 1))
-        item.update()
-        if shouldPlay {
-            player.play()
-            if state != .Playing {
-                state = .Playing
-            }
-        }
-        delegate?.jukeboxPlaybackProgressDidChange(self)
+        seekCurrentItem(toMillisecond: second * 1000, shouldPlay: shouldPlay)
+    }
+    
+    /**
+     Seeks to a certain millisecond within the current AVPlayerItem and starts playing
+     
+     - parameter millisecond: the millisecond to seek to
+     - parameter shouldPlay: pass true if playback should be resumed after seeking
+     */
+    public func seek(toMillisecond millisecond: Int, shouldPlay: Bool = false) {
+        seekCurrentItem(toMillisecond: millisecond, shouldPlay: shouldPlay)
     }
     
     /**
@@ -380,6 +380,20 @@ public class Jukebox: NSObject, JukeboxItemDelegate {
         startProgressTimer()
         seek(toSecond: 0, shouldPlay: true)
         updateInfoCenter()
+    }
+    
+    private func seekCurrentItem(toMillisecond millisecond: Int, shouldPlay: Bool) {
+        guard let player = player, let item = currentItem else {return}
+        
+        player.seekToTime(CMTimeMake(Int64(millisecond), 1000))
+        item.update()
+        if shouldPlay {
+            player.play()
+            if state != .Playing {
+                state = .Playing
+            }
+        }
+        delegate?.jukeboxPlaybackProgressDidChange(self)
     }
     
     // MARK: Items related

--- a/Source/JukeboxItem.swift
+++ b/Source/JukeboxItem.swift
@@ -34,10 +34,19 @@ protocol JukeboxItemDelegate : class {
 public class JukeboxItem: NSObject {
     
     public struct Meta {
+        /// The duration of the item in seconds.
         private(set) public var duration: Double?
+        
+        /// The title of the item.
         private(set) public var title: String?
+        
+        /// The album the item belongs to.
         private(set) public var album: String?
+        
+        /// The artist of the item.
         private(set) public var artist: String?
+        
+        /// The artwork of the item.
         private(set) public var artwork: UIImage?
     }
     


### PR DESCRIPTION
For shorter audio tracks, it can be useful to give the ability to seek to milliseconds (rather than seconds) so that the user has more granular control. Seeking to seconds on a very short audio track (such as a voice-recorded chat message which lasts only for a few seconds) can cause sliders which update based on the track's playback point to appear jumpy. Seeking to milliseconds instead allows for such UI interactions to be much smoother.
