### PR TITLE
Feature: Add ability to set custom metadata on JukeboxItem.

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -40,6 +40,11 @@ class ViewController: UIViewController, JukeboxDelegate {
             JukeboxItem(URL: URL(string: "http://www.noiseaddicts.com/samples_1w72b820/2958.mp3")!)
             ])!
         
+        // Add custom metadata
+        jukebox.currentItem?.customMetaBuilder = JukeboxItem.MetaBuilder({ (meta) in
+            meta.artist = "Jukebox Artist"
+        })
+        
         /// Later add another item
         let delay = DispatchTime.now() + Double(Int64(3 * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
         DispatchQueue.main.asyncAfter(deadline: delay) {

--- a/Jukebox.xcodeproj/project.pbxproj
+++ b/Jukebox.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		137DF0CD1D2044DF00C15E86 /* JukeboxItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137DF0C91D2044DF00C15E86 /* JukeboxItemTests.swift */; };
 		137DF0CE1D2044DF00C15E86 /* JukeboxTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137DF0CA1D2044DF00C15E86 /* JukeboxTestCase.swift */; };
 		137DF0CF1D2044DF00C15E86 /* JukeboxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137DF0CB1D2044DF00C15E86 /* JukeboxTests.swift */; };
+		D616D08E1E76B7D800C7AA32 /* JukeboxItemMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = D616D08D1E76B7D800C7AA32 /* JukeboxItemMeta.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,6 +38,7 @@
 		137DF0C91D2044DF00C15E86 /* JukeboxItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JukeboxItemTests.swift; sourceTree = "<group>"; };
 		137DF0CA1D2044DF00C15E86 /* JukeboxTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JukeboxTestCase.swift; sourceTree = "<group>"; };
 		137DF0CB1D2044DF00C15E86 /* JukeboxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JukeboxTests.swift; sourceTree = "<group>"; };
+		D616D08D1E76B7D800C7AA32 /* JukeboxItemMeta.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JukeboxItemMeta.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,6 +101,7 @@
 				137DF0C01D2044CE00C15E86 /* Jukebox.h */,
 				137DF0C11D2044CE00C15E86 /* Jukebox.swift */,
 				137DF0C21D2044CE00C15E86 /* JukeboxItem.swift */,
+				D616D08D1E76B7D800C7AA32 /* JukeboxItemMeta.swift */,
 			);
 			path = Source;
 			sourceTree = SOURCE_ROOT;
@@ -224,6 +227,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D616D08E1E76B7D800C7AA32 /* JukeboxItemMeta.swift in Sources */,
 				137DF0C51D2044CE00C15E86 /* Jukebox.swift in Sources */,
 				137DF0C61D2044CE00C15E86 /* JukeboxItem.swift in Sources */,
 			);

--- a/README.md
+++ b/README.md
@@ -253,6 +253,20 @@ public protocol JukeboxDelegate: class {
 }
 ```
 
+##<a name="metadata"> Metadata </a>
+
+Custom metadata can be defined for a `JukeboxItem` via a `JukeboxItemMetaBuilder`. Simple set the `customMetaBuilder` property on the item:
+
+```
+let item = JukeboxItem(URL: URL(string: "http://www.kissfm.ro/listen.pls")!)
+item.customMetaBuilder = JukeboxItemMetaBuilder({ (builder) in
+	builder.artist = "Custom Artist"
+	builder.artwork = UIImage(named: "CustomArtwork.png")
+})
+
+```
+Custom metadata takes precedence over any available data within the playable `AVPlayerItem`, however a combination of the two is used where available.
+
 ##<a name="license"> License </a>
 
 ```Jukebox``` is released under the MIT license. See the ```LICENSE``` file for details.

--- a/Source/JukeboxItemMeta.swift
+++ b/Source/JukeboxItemMeta.swift
@@ -1,0 +1,77 @@
+//
+//  JukeboxMeta.swift
+//  Jukebox
+//
+//  Created by Merrick Sapsford on 13/03/2017.
+//  Copyright © 2017 teodorpatras. All rights reserved.
+//
+
+import Foundation
+
+public extension JukeboxItem {
+    
+    /// Item Metadata
+    public class Meta: Any {
+        
+        /// The duration of the item
+        internal(set) public var duration: Double?
+        /// The title of the item.
+        internal(set) public var title: String?
+        /// The album name of the item.
+        internal(set) public var album: String?
+        /// The artist name of the item.
+        internal(set) public var artist: String?
+        /// Album artwork for the item.
+        internal(set) public var artwork: UIImage?
+    }
+    
+    /// Builder for custom Metadata
+    public class MetaBuilder: Meta {
+        public typealias MetaBuilderClosure = (MetaBuilder) -> ()
+        
+        // MARK: Properties
+        
+        private var _title: String?
+        public override var title: String? {
+            get {
+                return _title
+            } set (newTitle) {
+                _title = newTitle
+            }
+        }
+        
+        private var _album: String?
+        public override var album: String? {
+            get {
+                return _album
+            } set (newAlbum) {
+                _album = newAlbum
+            }
+        }
+        
+        private var _artist: String?
+        public override var artist: String? {
+            get {
+                return _artist
+            } set (newArtist) {
+                _artist = newArtist
+            }
+        }
+        
+        private var _artwork: UIImage?
+        public override var artwork: UIImage? {
+            get {
+                return _artwork
+            } set (newArtwork) {
+                _artwork = newArtwork
+            }
+        }
+        
+        // MARK: Init
+        
+        public init(_ build: MetaBuilderClosure) {
+            super.init()
+            build(self)
+        }
+    }
+}


### PR DESCRIPTION
Adds `JukeboxItemMetaBuilder` to allow for custom metadata to be specified for a `JukeboxItem`. A new public `customMetaBuilder` property is available on JukeboxItem; simply provide this with a builder with your custom data.

Custom metadata takes precedence over any collected from `AVMetadataItem`, however a combination of the two is still evaluated and used where appropriate.

Resolves #41. 