### PR TITLE
Moved Creation of AVURLAsset to background thread. 

### DIFF
--- a/Source/JukeboxItem.swift
+++ b/Source/JukeboxItem.swift
@@ -168,13 +168,14 @@ open class JukeboxItem: NSObject {
     }
     
     fileprivate func loadAsync(_ completion: @escaping (_ asset: AVURLAsset) -> ()) {
-        let asset = AVURLAsset(url: URL, options: nil)
-        
-        asset.loadValuesAsynchronously(forKeys: ["duration"], completionHandler: { () -> Void in
-            DispatchQueue.main.async {
-                completion(asset)
-            }
-        })
+        DispatchQueue.global(qos: .background).async {
+            let asset = AVURLAsset(url: self.URL, options: nil)
+            asset.loadValuesAsynchronously(forKeys: ["duration"], completionHandler: { () -> Void in
+                DispatchQueue.main.async {
+                    completion(asset)
+                }
+            })
+        }
     }
     
     fileprivate func configureMetadata()


### PR DESCRIPTION
Addresses Issue #57

AVURLAsset has some undocumented behavior where passing specific url's
to it with the AVAsset(url:) initializer will cause main thread stalls.

I simply moved the creation of this object onto a background thread to
avoid any of these potential stalls happening on the main thread.