### PR TITLE
fix: seek method did notify delegate to early

### DIFF
--- a/Source/Jukebox.swift
+++ b/Source/Jukebox.swift
@@ -141,8 +141,8 @@ extension Jukebox {
             item.update()
             if shouldPlay {
                 player.play()
-                if state != .playing {
-                    state = .playing
+                if self.state != .playing {
+                    self.state = .playing
                 }
             }
             self.delegate?.jukeboxPlaybackProgressDidChange(self)

--- a/Source/Jukebox.swift
+++ b/Source/Jukebox.swift
@@ -136,15 +136,17 @@ extension Jukebox {
     public func seek(toSecond second: Int, shouldPlay: Bool = false) {
         guard let player = player, let item = currentItem else {return}
         
-        player.seek(to: CMTimeMake(Int64(second), 1))
-        item.update()
-        if shouldPlay {
-            player.play()
-            if state != .playing {
-                state = .playing
+        player.seek(to: CMTimeMake(value: Int64(second), timescale: 1), completionHandler: { [weak self] finished in
+            guard finished, let `self` = self else { return }
+            item.update()
+            if shouldPlay {
+                player.play()
+                if state != .playing {
+                    state = .playing
+                }
             }
-        }
-        delegate?.jukeboxPlaybackProgressDidChange(self)
+            self.delegate?.jukeboxPlaybackProgressDidChange(self)
+        })
     }
     
     /**


### PR DESCRIPTION
When seeking the jukebox didn't wait for AVPlayer to finish seeking before notifying delegate.
When delegate receives this message, progress is still on state before seeking.

AVPlayer offers a method with completionBlock, which is called when seeking is finished. 
Using this completionBlock to notify the delegate resolves some issues with seeking.